### PR TITLE
Open Street Map Loader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 - >
   conda create -q -c synthicity -n test-environment
   python=$TRAVIS_PYTHON_VERSION
-  matplotlib numpy pandas pip pytables
+  matplotlib numpy pandas pip pytables requests
 - source activate test-environment
 - pip install brewer2mpl
 - pip install pytest-cov coveralls pep8

--- a/conftest.py
+++ b/conftest.py
@@ -25,6 +25,6 @@ import pandana.network as pdna
 if os.environ.get('TRAVIS') == 'true':
     num_networks_tested = 1
 else:
-    num_networks_tested = 4
+    num_networks_tested = 5
 
 pdna.reserve_num_graphs(num_networks_tested)

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 import pandana.network as pdna
 
 # Pandana uses global state for networks,
@@ -7,5 +9,22 @@ import pandana.network as pdna
 # If you see an error that looks like:
 #     AssertionError: Adding more networks than have been reserved
 # then you probably need to update this number.
-num_networks_tested = 2
+#
+# The tests seem to crash on Travis when more than one Network is made,
+# so always have one Network there.
+# If you add new tests that create a Network you'll need to mark them
+# so they are skipped on Travis. E.g.:
+#
+#     @pytest.mark.skipif(
+#         os.environ.get('TRAVIS') == 'true', reason='skip on Travis-CI')
+#     def test_network_from_bbox(bbox2):
+#
+# You'll also need to increment the non-Travis number of tests below
+# to match the number of Networks created while running tests locally.
+
+if os.environ.get('TRAVIS') == 'true':
+    num_networks_tested = 1
+else:
+    num_networks_tested = 2
+
 pdna.reserve_num_graphs(num_networks_tested)

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,11 @@
+import pandana.network as pdna
+
+# Pandana uses global state for networks,
+# so we have to pre-declare here how many networks will be
+# created during testing.
+#
+# If you see an error that looks like:
+#     AssertionError: Adding more networks than have been reserved
+# then you probably need to update this number.
+num_networks_tested = 2
+pdna.reserve_num_graphs(num_networks_tested)

--- a/conftest.py
+++ b/conftest.py
@@ -25,6 +25,6 @@ import pandana.network as pdna
 if os.environ.get('TRAVIS') == 'true':
     num_networks_tested = 1
 else:
-    num_networks_tested = 2
+    num_networks_tested = 4
 
 pdna.reserve_num_graphs(num_networks_tested)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ Contents
    introduction
    tutorial
    network
+   loaders
    futurework
 
 Indices and tables

--- a/docs/loaders.rst
+++ b/docs/loaders.rst
@@ -1,0 +1,89 @@
+Loaders
+=======
+
+Pandana has some support for creating a
+:py:class:`~pandana.network.Network` from
+the `OpenStreetMap <http://www.openstreetmap.org/>`__ API,
+and for storing ``Network`` data to disk as HDF5 so that it can be
+restored later.
+
+OpenStreetMap
+-------------
+
+A :py:class:`~pandana.network.Network` is created from OpenStreetMap using
+the :py:func:`~pandana.loaders.osm.network_from_bbox` function::
+
+    from pandana.loaders import osm
+    network = osm.network_from_bbox(37.859, -122.282, 37.881, -122.252)
+
+By default the generated network contains only walkable routes,
+specify ``type='drive'`` to get driveable routes.
+These networks have one impedance set, named ``'distance'``,
+which is the distance between nodes in meters.
+
+The OSM API also includes the :py:func:`~pandana.loaders.osm.node_query`
+function for getting specific nodes within a bounding box.
+This can be used to populate a network with points of interest::
+
+    nodes = osm.node_query(
+        37.859, -122.282, 37.881, -122.252, tags='"amenity"="restaurant"')
+    network.init_pois(num_categories=1, max_dist=2000, max_pois=10)
+    network.set_pois('restaurants', nodes['lon'], nodes['lat'])
+
+For more about tags see the
+`Overpass API Language Guide <http://wiki.openstreetmap.org/wiki/Overpass_API/Language_Guide>`__
+and the list of
+`OSM map features <http://wiki.openstreetmap.org/wiki/Map_Features>`__.
+
+Pandas HDF5
+-----------
+
+Saving a ``Network`` to HDF5 is a way to share a ``Network`` or to preserve
+it between sessions. For example. you can build a ``Network`` using the
+OpenStreetMap API, then save the ``Network`` to HDF5 so you can reuse it
+without querying OSM again.
+Users will typically use the
+:py:meth:`~pandana.network.Network.save_hdf5` and
+:py:meth:`~pandana.network.Network.from_hdf5` methods.
+
+.. note::
+   Only the nodes and edges of the network are saved.
+   Points-of-interest and data attached to nodes via the
+   :py:meth:`~pandana.network.Network.set` method are not included.
+
+   You may find the
+   `Pandas HDFStore <http://pandas.pydata.org/pandas-docs/stable/io.html#io-hdf5>`__
+   useful to save POI and other data.
+
+When saving a ``Network`` to HDF5 it's possible to exclude certain nodes.
+This can be useful when refining a network so that it includes only
+validated nodes.
+(In the current design of Pandana it's not possible to modify a
+``Network`` in place.)
+As an example, you can use the
+:py:meth:`~pandana.network.Network.low_connectivity_nodes` method
+to identify nodes that may not be connected to the larger network,
+then exclude those nodes when saving to HDF5::
+
+    lcn = network.low_connectivity_nodes(10000, 10, imp_name='distance')
+    network.save_hdf5('mynetwork.h5', rm_nodes=lcn)
+
+OpenStreetMap API
+-----------------
+
+.. autofunction:: pandana.loaders.osm.network_from_bbox
+
+.. autofunction:: pandana.loaders.osm.node_query
+
+Pandas HDF5 API
+---------------
+
+.. automethod:: pandana.network.Network.save_hdf5
+   :noindex:
+
+.. automethod:: pandana.network.Network.from_hdf5
+   :noindex:
+
+.. autofunction:: pandana.loaders.pandash5.network_to_pandas_hdf5
+
+.. autofunction:: pandana.loaders.pandash5.network_from_pandas_hdf5

--- a/pandana/loaders/osm.py
+++ b/pandana/loaders/osm.py
@@ -2,7 +2,19 @@
 Tools for creating Pandana networks from Open Street Map.
 
 """
+import pandas as pd
 import requests
+
+uninteresting_tags = {
+    'source',
+    'source_ref',
+    'source:ref',
+    'history',
+    'attribution',
+    'created_by',
+    'tiger:tlid',
+    'tiger:upload_uuid',
+}
 
 
 def osm_query(lat_min, lng_min, lat_max, lng_max):
@@ -50,3 +62,94 @@ def make_osm_query(lat_min, lng_min, lat_max, lng_max):
 
     return req.json()
 
+
+def process_node(e):
+    """
+    Process a node element entry into a dict suitable for going into
+    a Pandas DataFrame.
+
+    Parameters
+    ----------
+    e : dict
+
+    Returns
+    -------
+    node : dict
+
+    """
+    node = {
+        'id': e['id'],
+        'lat': e['lat'],
+        'lon': e['lon']
+    }
+
+    if 'tags' in e:
+        for t, v in e['tags'].items():
+            if t not in uninteresting_tags:
+                node[t] = v
+
+    return node
+
+
+def process_way(e):
+    """
+    Process a way element entry into a list of dicts suitable for going into
+    a Pandas DataFrame.
+
+    Parameters
+    ----------
+    e : dict
+
+    Returns
+    -------
+    way : dict
+    waynodes : list of dict
+
+    """
+    way = {
+        'id': e['id']
+    }
+
+    if 'tags' in e:
+        for t, v in e['tags'].items():
+            if t not in uninteresting_tags:
+                way[t] = v
+
+    waynodes = []
+
+    for n in e['nodes']:
+        waynodes.append({'way_id': e['id'], 'node_id': n})
+
+    return way, waynodes
+
+
+def parse_osm_query(data):
+    """
+    Convert OSM query data to DataFrames of ways and way-nodes.
+
+    Parameters
+    ----------
+    data : dict
+        Result of an OSM query.
+
+    Returns
+    -------
+    nodes, ways, waynodes : pandas.DataFrame
+
+    """
+    nodes = []
+    ways = []
+    waynodes = []
+
+    for e in data['elements']:
+        if e['type'] == 'node':
+            nodes.append(process_node(e))
+        elif e['type'] == 'way':
+            w, wn = process_way(e)
+            ways.append(w)
+            waynodes.extend(wn)
+
+    return (
+        pd.DataFrame.from_records(nodes, index='id'),
+        pd.DataFrame.from_records(ways, index='id'),
+        pd.DataFrame.from_records(waynodes, index='way_id'))

--- a/pandana/loaders/osm.py
+++ b/pandana/loaders/osm.py
@@ -22,7 +22,7 @@ uninteresting_tags = {
 }
 
 
-def osm_query(lat_min, lng_min, lat_max, lng_max, network_type='walk'):
+def network_osm_query(lat_min, lng_min, lat_max, lng_max, network_type='walk'):
     """
     Construct an OSM way query for a bounding box.
 
@@ -63,7 +63,8 @@ def osm_query(lat_min, lng_min, lat_max, lng_max, network_type='walk'):
         filters=filters)
 
 
-def make_osm_query(lat_min, lng_min, lat_max, lng_max, network_type='walk'):
+def make_network_osm_query(
+        lat_min, lng_min, lat_max, lng_max, network_type='walk'):
     """
     Make a request to OSM and return the parsed JSON.
 
@@ -82,7 +83,7 @@ def make_osm_query(lat_min, lng_min, lat_max, lng_max, network_type='walk'):
 
     """
     osm_url = 'http://www.overpass-api.de/api/interpreter'
-    query = osm_query(
+    query = network_osm_query(
         lat_min, lng_min, lat_max, lng_max, network_type=network_type)
 
     req = requests.get(osm_url, params={'data': query})
@@ -151,7 +152,7 @@ def process_way(e):
     return way, waynodes
 
 
-def parse_osm_query(data):
+def parse_network_osm_query(data):
     """
     Convert OSM query data to DataFrames of ways and way-nodes.
 
@@ -201,7 +202,7 @@ def ways_in_bbox(lat_min, lng_min, lat_max, lng_max, network_type='walk'):
     nodes, ways, waynodes : pandas.DataFrame
 
     """
-    return parse_osm_query(make_osm_query(
+    return parse_network_osm_query(make_network_osm_query(
         lat_min, lng_min, lat_max, lng_max, network_type=network_type))
 
 

--- a/pandana/loaders/osm.py
+++ b/pandana/loaders/osm.py
@@ -1,0 +1,52 @@
+"""
+Tools for creating Pandana networks from Open Street Map.
+
+"""
+import requests
+
+
+def osm_query(lat_min, lng_min, lat_max, lng_max):
+    """
+    Construct an OSM way query for a bounding box.
+
+    Parameters
+    ----------
+    lat_min, lng_min, lat_max, lng_max : float
+
+    Returns
+    -------
+    query : str
+
+    """
+    query_fmt = (
+        '[out:json];'
+        '('
+        '  way({lat_min},{lng_min},{lat_max},{lng_max});'
+        '  >;'  # the '>' makes it recurse so we get ways and way nodes
+        ');'
+        'out;')
+    return query_fmt.format(
+        lat_min=lat_min, lng_min=lng_min, lat_max=lat_max, lng_max=lng_max)
+
+
+def make_osm_query(lat_min, lng_min, lat_max, lng_max):
+    """
+    Make a request to OSM and return the parsed JSON.
+
+    Parameters
+    ----------
+    lat_min, lng_min, lat_max, lng_max : float
+
+    Returns
+    -------
+    data : dict
+
+    """
+    osm_url = 'http://www.overpass-api.de/api/interpreter'
+    query = osm_query(lat_min, lng_min, lat_max, lng_max)
+
+    req = requests.get(osm_url, params={'data': query})
+    req.raise_for_status()
+
+    return req.json()
+

--- a/pandana/loaders/osm.py
+++ b/pandana/loaders/osm.py
@@ -22,14 +22,14 @@ uninteresting_tags = {
 }
 
 
-def osm_query(lat_min, lng_min, lat_max, lng_max, network='walk'):
+def osm_query(lat_min, lng_min, lat_max, lng_max, network_type='walk'):
     """
     Construct an OSM way query for a bounding box.
 
     Parameters
     ----------
     lat_min, lng_min, lat_max, lng_max : float
-    network : {'walk', 'drive'}, optional
+    network_type : {'walk', 'drive'}, optional
         Specify whether the network will be used for walking or driving.
         A value of 'walk' attempts to exclude things like freeways,
         while a value of 'drive' attempts to exclude things like
@@ -51,26 +51,26 @@ def osm_query(lat_min, lng_min, lat_max, lng_max, network='walk'):
         ');'
         'out;')
 
-    if network == 'walk':
+    if network_type == 'walk':
         filters = '["highway"!~"motor"]'
-    elif network == 'drive':
+    elif network_type == 'drive':
         filters = '["highway"!~"foot|cycle"]'
     else:
-        raise ValueError('Invalid network argument')
+        raise ValueError('Invalid network_type argument')
 
     return query_fmt.format(
         lat_min=lat_min, lng_min=lng_min, lat_max=lat_max, lng_max=lng_max,
         filters=filters)
 
 
-def make_osm_query(lat_min, lng_min, lat_max, lng_max, network='walk'):
+def make_osm_query(lat_min, lng_min, lat_max, lng_max, network_type='walk'):
     """
     Make a request to OSM and return the parsed JSON.
 
     Parameters
     ----------
     lat_min, lng_min, lat_max, lng_max : float
-    network : {'walk', 'drive'}, optional
+    network_type : {'walk', 'drive'}, optional
         Specify whether the network will be used for walking or driving.
         A value of 'walk' attempts to exclude things like freeways,
         while a value of 'drive' attempts to exclude things like
@@ -82,7 +82,8 @@ def make_osm_query(lat_min, lng_min, lat_max, lng_max, network='walk'):
 
     """
     osm_url = 'http://www.overpass-api.de/api/interpreter'
-    query = osm_query(lat_min, lng_min, lat_max, lng_max, network=network)
+    query = osm_query(
+        lat_min, lng_min, lat_max, lng_max, network_type=network_type)
 
     req = requests.get(osm_url, params={'data': query})
     req.raise_for_status()
@@ -182,14 +183,14 @@ def parse_osm_query(data):
         pd.DataFrame.from_records(waynodes, index='way_id'))
 
 
-def ways_in_bbox(lat_min, lng_min, lat_max, lng_max, network='walk'):
+def ways_in_bbox(lat_min, lng_min, lat_max, lng_max, network_type='walk'):
     """
     Get DataFrames of OSM data in a bounding box.
 
     Parameters
     ----------
     lat_min, lng_min, lat_max, lng_max : float
-    network : {'walk', 'drive'}, optional
+    network_type : {'walk', 'drive'}, optional
         Specify whether the network will be used for walking or driving.
         A value of 'walk' attempts to exclude things like freeways,
         while a value of 'drive' attempts to exclude things like
@@ -201,7 +202,7 @@ def ways_in_bbox(lat_min, lng_min, lat_max, lng_max, network='walk'):
 
     """
     return parse_osm_query(make_osm_query(
-        lat_min, lng_min, lat_max, lng_max, network=network))
+        lat_min, lng_min, lat_max, lng_max, network_type=network_type))
 
 
 def intersection_nodes(waynodes):
@@ -288,14 +289,14 @@ def node_pairs(nodes, ways, waynodes, two_way=True):
 
 
 def network_from_bbox(
-        lat_min, lng_min, lat_max, lng_max, network='walk', two_way=True):
+        lat_min, lng_min, lat_max, lng_max, network_type='walk', two_way=True):
     """
     Make a Pandana network from a bounding lat/lon box.
 
     Parameters
     ----------
     lat_min, lng_min, lat_max, lng_max : float
-    network : {'walk', 'drive'}, optional
+    network_type : {'walk', 'drive'}, optional
         Specify whether the network will be used for walking or driving.
         A value of 'walk' attempts to exclude things like freeways,
         while a value of 'drive' attempts to exclude things like
@@ -310,7 +311,7 @@ def network_from_bbox(
 
     """
     nodes, ways, waynodes = ways_in_bbox(
-        lat_min, lng_min, lat_max, lng_max, network)
+        lat_min, lng_min, lat_max, lng_max, network_type)
     pairs = node_pairs(nodes, ways, waynodes, two_way=two_way)
 
     # make the unique set of nodes that ended up in pairs

--- a/pandana/loaders/osm.py
+++ b/pandana/loaders/osm.py
@@ -155,3 +155,19 @@ def parse_osm_query(data):
         pd.DataFrame.from_records(nodes, index='id'),
         pd.DataFrame.from_records(ways, index='id'),
         pd.DataFrame.from_records(waynodes, index='way_id'))
+
+
+def ways_in_bbox(lat_min, lng_min, lat_max, lng_max):
+    """
+    Get DataFrames of OSM data in a bounding box.
+
+    Parameters
+    ----------
+    lat_min, lng_min, lat_max, lng_max : float
+
+    Returns
+    -------
+    nodes, ways, waynodes : pandas.DataFrame
+
+    """
+    return parse_osm_query(make_osm_query(lat_min, lng_min, lat_max, lng_max))

--- a/pandana/loaders/osm.py
+++ b/pandana/loaders/osm.py
@@ -22,7 +22,8 @@ uninteresting_tags = {
 }
 
 
-def network_osm_query(lat_min, lng_min, lat_max, lng_max, network_type='walk'):
+def build_network_osm_query(
+        lat_min, lng_min, lat_max, lng_max, network_type='walk'):
     """
     Construct an OSM way query for a bounding box.
 
@@ -63,19 +64,14 @@ def network_osm_query(lat_min, lng_min, lat_max, lng_max, network_type='walk'):
         filters=filters)
 
 
-def make_network_osm_query(
-        lat_min, lng_min, lat_max, lng_max, network_type='walk'):
+def make_osm_query(query):
     """
     Make a request to OSM and return the parsed JSON.
 
     Parameters
     ----------
-    lat_min, lng_min, lat_max, lng_max : float
-    network_type : {'walk', 'drive'}, optional
-        Specify whether the network will be used for walking or driving.
-        A value of 'walk' attempts to exclude things like freeways,
-        while a value of 'drive' attempts to exclude things like
-        bike and walking paths.
+    query : str
+        A string in the Overpass QL format.
 
     Returns
     -------
@@ -83,9 +79,6 @@ def make_network_osm_query(
 
     """
     osm_url = 'http://www.overpass-api.de/api/interpreter'
-    query = network_osm_query(
-        lat_min, lng_min, lat_max, lng_max, network_type=network_type)
-
     req = requests.get(osm_url, params={'data': query})
     req.raise_for_status()
 
@@ -202,8 +195,8 @@ def ways_in_bbox(lat_min, lng_min, lat_max, lng_max, network_type='walk'):
     nodes, ways, waynodes : pandas.DataFrame
 
     """
-    return parse_network_osm_query(make_network_osm_query(
-        lat_min, lng_min, lat_max, lng_max, network_type=network_type))
+    return parse_network_osm_query(make_osm_query(build_network_osm_query(
+        lat_min, lng_min, lat_max, lng_max, network_type=network_type)))
 
 
 def intersection_nodes(waynodes):
@@ -323,3 +316,71 @@ def network_from_bbox(
     return Network(
         nodes['lon'], nodes['lat'],
         pairs['from_id'], pairs['to_id'], pairs[['distance']])
+
+
+def build_node_query(lat_min, lng_min, lat_max, lng_max, tags=None):
+    """
+    Build the string for a node-based OSM query.
+
+    Parameters
+    ----------
+    lat_min, lng_min, lat_max, lng_max : float
+    tags : str or list of str, optional
+        Node tags that will be used to filter the search.
+        See http://wiki.openstreetmap.org/wiki/Overpass_API/Language_Guide
+        for information about OSM Overpass queries
+        and http://wiki.openstreetmap.org/wiki/Map_Features
+        for a list of tags.
+
+    Returns
+    -------
+    query : str
+
+    """
+    if tags is not None:
+        if isinstance(tags, str):
+            tags = [tags]
+        tags = ''.join('[{}]'.format(t) for t in tags)
+    else:
+        tags = ''
+
+    query_fmt = (
+        '[out:json];'
+        '('
+        '  node'
+        '  {tags}'
+        '  ({lat_min},{lng_min},{lat_max},{lng_max});'
+        ');'
+        'out;')
+
+    return query_fmt.format(
+        lat_min=lat_min, lng_min=lng_min, lat_max=lat_max, lng_max=lng_max,
+        tags=tags)
+
+
+def node_query(lat_min, lng_min, lat_max, lng_max, tags=None):
+    """
+    Search for OSM nodes within a bounding box that match given tags.
+
+    Parameters
+    ----------
+    lat_min, lng_min, lat_max, lng_max : float
+    tags : str or list of str, optional
+        Node tags that will be used to filter the search.
+        See http://wiki.openstreetmap.org/wiki/Overpass_API/Language_Guide
+        for information about OSM Overpass queries
+        and http://wiki.openstreetmap.org/wiki/Map_Features
+        for a list of tags.
+
+    Returns
+    -------
+    nodes : pandas.DataFrame
+        Will have 'lat' and 'lon' columns, plus other columns for the
+        tags associated with the node (these will vary based on the query).
+        Index will be the OSM node IDs.
+
+    """
+    node_data = make_osm_query(build_node_query(
+        lat_min, lng_min, lat_max, lng_max, tags=tags))
+    nodes = [process_node(n) for n in node_data['elements']]
+    return pd.DataFrame.from_records(nodes, index='id')

--- a/pandana/loaders/osm.py
+++ b/pandana/loaders/osm.py
@@ -159,6 +159,9 @@ def parse_network_osm_query(data):
     nodes, ways, waynodes : pandas.DataFrame
 
     """
+    if len(data['elements']) == 0:
+        raise RuntimeError('OSM query results contain no data.')
+
     nodes = []
     ways = []
     waynodes = []
@@ -382,5 +385,9 @@ def node_query(lat_min, lng_min, lat_max, lng_max, tags=None):
     """
     node_data = make_osm_query(build_node_query(
         lat_min, lng_min, lat_max, lng_max, tags=tags))
+
+    if len(node_data['elements']) == 0:
+        raise RuntimeError('OSM query results contain no data.')
+
     nodes = [process_node(n) for n in node_data['elements']]
     return pd.DataFrame.from_records(nodes, index='id')

--- a/pandana/loaders/osm.py
+++ b/pandana/loaders/osm.py
@@ -33,7 +33,9 @@ def osm_query(lat_min, lng_min, lat_max, lng_max):
     query_fmt = (
         '[out:json];'
         '('
-        '  way({lat_min},{lng_min},{lat_max},{lng_max});'
+        '  way'
+        '  ["highway"]'
+        '  ({lat_min},{lng_min},{lat_max},{lng_max});'
         '  >;'  # the '>' makes it recurse so we get ways and way nodes
         ');'
         'out;')

--- a/pandana/loaders/osm.py
+++ b/pandana/loaders/osm.py
@@ -171,3 +171,22 @@ def ways_in_bbox(lat_min, lng_min, lat_max, lng_max):
 
     """
     return parse_osm_query(make_osm_query(lat_min, lng_min, lat_max, lng_max))
+
+
+def intersection_nodes(waynodes):
+    """
+    Returns a set of all the nodes that appear in 2 or more ways.
+
+    Parameters
+    ----------
+    waynodes : pandas.DataFrame
+        Mapping of way IDs to node IDs as returned by `ways_in_bbox`.
+
+    Returns
+    -------
+    intersections : set
+        Node IDs that appear in 2 or more ways.
+
+    """
+    counts = waynodes.node_id.value_counts()
+    return set(counts[counts > 1].index.values)

--- a/pandana/loaders/pandash5.py
+++ b/pandana/loaders/pandash5.py
@@ -1,7 +1,5 @@
 import pandas as pd
 
-from ..network import Network
-
 
 def remove_nodes(network, rm_nodes):
     """
@@ -55,12 +53,14 @@ def network_to_pandas_hdf5(network, filename, rm_nodes=None):
         store['impedance_names'] = pd.Series(network.impedance_names)
 
 
-def network_from_pandas_hdf5(filename):
+def network_from_pandas_hdf5(cls, filename):
     """
     Build a Network from data in a Pandas HDFStore.
 
     Parameters
     ----------
+    cls : class
+        Class to instantiate, usually pandana.Network.
     filename : str
 
     Returns
@@ -74,6 +74,6 @@ def network_from_pandas_hdf5(filename):
         two_way = store['two_way'][0]
         imp_names = store['impedance_names'].tolist()
 
-    return Network(
+    return cls(
         nodes['x'], nodes['y'], edges['from'], edges['to'], edges[imp_names],
         twoway=two_way)

--- a/pandana/loaders/pandash5.py
+++ b/pandana/loaders/pandash5.py
@@ -1,0 +1,79 @@
+import pandas as pd
+
+from ..network import Network
+
+
+def remove_nodes(network, rm_nodes):
+    """
+    Create DataFrames of nodes and edges that do not include specified nodes.
+
+    Parameters
+    ----------
+    network : pandana.Network
+    rm_nodes : array_like
+        A list, array, Index, or Series of node IDs that should *not*
+        be saved as part of the Network.
+
+    Returns
+    -------
+    nodes, edges : pandas.DataFrame
+
+    """
+    rm_nodes = set(rm_nodes)
+    ndf = network.nodes_df
+    edf = network.edges_df
+
+    nodes_to_keep = ~ndf.index.isin(rm_nodes)
+    edges_to_keep = ~(edf['from'].isin(rm_nodes) | edf['to'].isin(rm_nodes))
+
+    return ndf.loc[nodes_to_keep], edf.loc[edges_to_keep]
+
+
+def network_to_pandas_hdf5(network, filename, rm_nodes=None):
+    """
+    Save a Network's data to a Pandas HDFStore.
+
+    Parameters
+    ----------
+    network : pandana.Network
+    filename : str
+    rm_nodes : array_like
+        A list, array, Index, or Series of node IDs that should *not*
+        be saved as part of the Network.
+
+    """
+    if rm_nodes is not None:
+        nodes, edges = remove_nodes(network, rm_nodes)
+    else:
+        nodes, edges = network.nodes_df, network.edges_df
+
+    with pd.HDFStore(filename, mode='w') as store:
+        store['nodes'] = nodes
+        store['edges'] = edges
+
+        store['two_way'] = pd.Series([network._twoway])
+        store['impedance_names'] = pd.Series(network.impedance_names)
+
+
+def network_from_pandas_hdf5(filename):
+    """
+    Build a Network from data in a Pandas HDFStore.
+
+    Parameters
+    ----------
+    filename : str
+
+    Returns
+    -------
+    network : pandana.Network
+
+    """
+    with pd.HDFStore(filename) as store:
+        nodes = store['nodes']
+        edges = store['edges']
+        two_way = store['two_way'][0]
+        imp_names = store['impedance_names'].tolist()
+
+    return Network(
+        nodes['x'], nodes['y'], edges['from'], edges['to'], edges[imp_names],
+        twoway=two_way)

--- a/pandana/loaders/tests/test_osm.py
+++ b/pandana/loaders/tests/test_osm.py
@@ -136,11 +136,11 @@ def test_ways_in_bbox(bbox1, dataframes1):
 
 
 @pytest.mark.parametrize(
-    'network, noset',
+    'network_type, noset',
     [('walk', {'motorway', 'motorway_link'}),
      ('drive', {'footway', 'cycleway'})])
-def test_ways_in_bbox_walk_network(bbox3, network, noset):
-    nodes, ways, waynodes = osm.ways_in_bbox(*bbox3, network=network)
+def test_ways_in_bbox_walk_network(bbox3, network_type, noset):
+    nodes, ways, waynodes = osm.ways_in_bbox(*bbox3, network_type=network_type)
 
     for _, way in ways.iterrows():
         assert way['highway'] not in noset

--- a/pandana/loaders/tests/test_osm.py
+++ b/pandana/loaders/tests/test_osm.py
@@ -32,25 +32,25 @@ def bbox3():
 
 @pytest.fixture(scope='module')
 def query_data1(bbox1):
-    return osm.make_osm_query(*bbox1)
+    return osm.make_network_osm_query(*bbox1)
 
 
 @pytest.fixture(scope='module')
 def query_data2(bbox2):
-    return osm.make_osm_query(*bbox2)
+    return osm.make_network_osm_query(*bbox2)
 
 
 @pytest.fixture(scope='module')
 def dataframes1(query_data1):
-    return osm.parse_osm_query(query_data1)
+    return osm.parse_network_osm_query(query_data1)
 
 
 @pytest.fixture(scope='module')
 def dataframes2(query_data2):
-    return osm.parse_osm_query(query_data2)
+    return osm.parse_network_osm_query(query_data2)
 
 
-def test_make_osm_query(query_data1):
+def test_make_network_osm_query(query_data1):
     assert isinstance(query_data1, dict)
     assert len(query_data1['elements']) == 24
     assert len(
@@ -119,7 +119,7 @@ def test_process_way():
     assert waynodes == expected_waynodes
 
 
-def test_parse_osm_query(dataframes1):
+def test_parse_network_osm_query(dataframes1):
     nodes, ways, waynodes = dataframes1
 
     assert len(nodes) == 22

--- a/pandana/loaders/tests/test_osm.py
+++ b/pandana/loaders/tests/test_osm.py
@@ -1,3 +1,4 @@
+import pandas.util.testing as pdt
 import pytest
 
 from pandana.loaders import osm
@@ -5,6 +6,7 @@ from pandana.loaders import osm
 
 @pytest.fixture(scope='module')
 def bbox():
+    # Intersection of Telegraph and Haste in Berkeley
     return 37.8659303546, -122.2588003879, 37.8661598571, -122.2585062512
 
 
@@ -88,3 +90,12 @@ def test_parse_osm_query(query_data):
     assert len(nodes) == 22
     assert len(ways) == 2
     assert len(waynodes.index.unique()) == 2
+
+
+def test_ways_in_bbox(bbox, query_data):
+    nodes, ways, waynodes = osm.ways_in_bbox(*bbox)
+    exp_nodes, exp_ways, exp_waynodes = osm.parse_osm_query(query_data)
+
+    pdt.assert_frame_equal(nodes, exp_nodes)
+    pdt.assert_frame_equal(ways, exp_ways)
+    pdt.assert_frame_equal(waynodes, exp_waynodes)

--- a/pandana/loaders/tests/test_osm.py
+++ b/pandana/loaders/tests/test_osm.py
@@ -20,6 +20,15 @@ def bbox2():
 
 
 @pytest.fixture(scope='module')
+def bbox3():
+    # West Berkeley including highway 80, frontage roads, and foot paths
+    # Sample query: http://overpass-turbo.eu/s/6VE
+    return (
+        37.85225504880375, -122.30295896530151,
+        37.85776128099243, - 122.2954273223877)
+
+
+@pytest.fixture(scope='module')
 def query_data1(bbox1):
     return osm.make_osm_query(*bbox1)
 
@@ -123,6 +132,17 @@ def test_ways_in_bbox(bbox1, dataframes1):
     pdt.assert_frame_equal(nodes, exp_nodes)
     pdt.assert_frame_equal(ways, exp_ways)
     pdt.assert_frame_equal(waynodes, exp_waynodes)
+
+
+@pytest.mark.parametrize(
+    'network, noset',
+    [('walk', {'motorway', 'motorway_link'}),
+     ('drive', {'footway', 'cycleway'})])
+def test_ways_in_bbox_walk_network(bbox3, network, noset):
+    nodes, ways, waynodes = osm.ways_in_bbox(*bbox3, network=network)
+
+    for _, way in ways.iterrows():
+        assert way['highway'] not in noset
 
 
 def test_intersection_nodes1(dataframes1):

--- a/pandana/loaders/tests/test_osm.py
+++ b/pandana/loaders/tests/test_osm.py
@@ -3,14 +3,88 @@ import pytest
 from pandana.loaders import osm
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def bbox():
     return 37.8659303546, -122.2588003879, 37.8661598571, -122.2585062512
 
 
-def test_make_osm_query(bbox):
-    data = osm.make_osm_query(*bbox)
-    assert isinstance(data, dict)
-    assert len(data['elements']) == 37
-    assert len([e for e in data['elements'] if e['type'] == 'node']) == 33
-    assert len([e for e in data['elements'] if e['type'] == 'way']) == 4
+@pytest.fixture(scope='module')
+def query_data(bbox):
+    return osm.make_osm_query(*bbox)
+
+
+def test_make_osm_query(query_data):
+    assert isinstance(query_data, dict)
+    assert len(query_data['elements']) == 37
+    assert len(
+        [e for e in query_data['elements'] if e['type'] == 'node']) == 33
+    assert len([e for e in query_data['elements'] if e['type'] == 'way']) == 4
+
+
+def test_process_node():
+    test_node = {
+        'id': 'id',
+        'lat': 'lat',
+        'lon': 'lon',
+        'extra': 'extra'
+    }
+
+    expected = {
+        'id': 'id',
+        'lat': 'lat',
+        'lon': 'lon'
+    }
+
+    assert osm.process_node(test_node) == expected
+
+    test_node['tags'] = {'highway': 'highway', 'source': 'source'}
+    expected['highway'] = 'highway'
+
+    assert osm.process_node(test_node) == expected
+
+
+def test_process_way():
+    test_way = {
+        "type": "way",
+        "id": 188434143,
+        "timestamp": "2014-01-04T22:18:14Z",
+        "version": 2,
+        "changeset": 19814115,
+        "user": "dchiles",
+        "uid": 153669,
+        "nodes": [
+            53020977,
+            53041093,
+        ],
+        "tags": {
+            'source': 'source',
+            "addr:city": "Berkeley",
+            "highway": "secondary",
+            "name": "Telegraph Avenue",
+        }
+    }
+
+    expected_way = {
+        'id': test_way['id'],
+        'addr:city': test_way['tags']['addr:city'],
+        'highway': test_way['tags']['highway'],
+        'name': test_way['tags']['name']
+    }
+
+    expected_waynodes = [
+        {'way_id': test_way['id'], 'node_id': test_way['nodes'][0]},
+        {'way_id': test_way['id'], 'node_id': test_way['nodes'][1]}
+    ]
+
+    way, waynodes = osm.process_way(test_way)
+
+    assert way == expected_way
+    assert waynodes == expected_waynodes
+
+
+def test_parse_osm_query(query_data):
+    nodes, ways, waynodes = osm.parse_osm_query(query_data)
+
+    assert len(nodes) == 33
+    assert len(ways) == 4
+    assert len(waynodes.index.unique()) == 4

--- a/pandana/loaders/tests/test_osm.py
+++ b/pandana/loaders/tests/test_osm.py
@@ -2,6 +2,7 @@ import numpy.testing as npt
 import pandas.util.testing as pdt
 import pytest
 
+import pandana
 from pandana.loaders import osm
 
 
@@ -190,3 +191,8 @@ def test_node_pairs_one_way(dataframes2):
         assert pair.from_id == p1
         assert pair.to_id == p2
         npt.assert_allclose(pair.distance, 101.20535797547758)
+
+
+def test_network_from_bbox(bbox2):
+    net = osm.network_from_bbox(*bbox2)
+    assert isinstance(net, pandana.Network)

--- a/pandana/loaders/tests/test_osm.py
+++ b/pandana/loaders/tests/test_osm.py
@@ -127,6 +127,13 @@ def test_parse_network_osm_query(dataframes1):
     assert len(waynodes.index.unique()) == 2
 
 
+def test_parse_network_osm_query_raises():
+    data = osm.make_osm_query(osm.build_network_osm_query(
+        37.8, -122.252, 37.8, -122.252))
+    with pytest.raises(RuntimeError):
+        osm.parse_network_osm_query(data)
+
+
 def test_ways_in_bbox(bbox1, dataframes1):
     nodes, ways, waynodes = osm.ways_in_bbox(*bbox1)
     exp_nodes, exp_ways, exp_waynodes = dataframes1
@@ -249,3 +256,8 @@ def test_node_query(bbox2):
     assert 'lat' in cafes.columns
     assert 'lon' in cafes.columns
     assert cafes['name'][2965338413] == 'Koja Kitchen'
+
+
+def test_node_query_raises():
+    with pytest.raises(RuntimeError):
+        osm.node_query(37.8, -122.282, 37.8, -122.252)

--- a/pandana/loaders/tests/test_osm.py
+++ b/pandana/loaders/tests/test_osm.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy.testing as npt
 import pandas.util.testing as pdt
 import pytest
@@ -193,6 +195,8 @@ def test_node_pairs_one_way(dataframes2):
         npt.assert_allclose(pair.distance, 101.20535797547758)
 
 
+@pytest.mark.skipif(
+    os.environ.get('TRAVIS') == 'true', reason='skip on Travis-CI')
 def test_network_from_bbox(bbox2):
     net = osm.network_from_bbox(*bbox2)
     assert isinstance(net, pandana.Network)

--- a/pandana/loaders/tests/test_osm.py
+++ b/pandana/loaders/tests/test_osm.py
@@ -1,11 +1,10 @@
-import os
-
 import numpy.testing as npt
 import pandas.util.testing as pdt
 import pytest
 
 import pandana
 from pandana.loaders import osm
+from pandana.testing import skipiftravis
 
 
 @pytest.fixture(scope='module')
@@ -195,8 +194,7 @@ def test_node_pairs_one_way(dataframes2):
         npt.assert_allclose(pair.distance, 101.20535797547758)
 
 
-@pytest.mark.skipif(
-    os.environ.get('TRAVIS') == 'true', reason='skip on Travis-CI')
+@skipiftravis
 def test_network_from_bbox(bbox2):
     net = osm.network_from_bbox(*bbox2)
     assert isinstance(net, pandana.Network)

--- a/pandana/loaders/tests/test_osm.py
+++ b/pandana/loaders/tests/test_osm.py
@@ -15,10 +15,10 @@ def query_data(bbox):
 
 def test_make_osm_query(query_data):
     assert isinstance(query_data, dict)
-    assert len(query_data['elements']) == 37
+    assert len(query_data['elements']) == 24
     assert len(
-        [e for e in query_data['elements'] if e['type'] == 'node']) == 33
-    assert len([e for e in query_data['elements'] if e['type'] == 'way']) == 4
+        [e for e in query_data['elements'] if e['type'] == 'node']) == 22
+    assert len([e for e in query_data['elements'] if e['type'] == 'way']) == 2
 
 
 def test_process_node():
@@ -85,6 +85,6 @@ def test_process_way():
 def test_parse_osm_query(query_data):
     nodes, ways, waynodes = osm.parse_osm_query(query_data)
 
-    assert len(nodes) == 33
-    assert len(ways) == 4
-    assert len(waynodes.index.unique()) == 4
+    assert len(nodes) == 22
+    assert len(ways) == 2
+    assert len(waynodes.index.unique()) == 2

--- a/pandana/loaders/tests/test_osm.py
+++ b/pandana/loaders/tests/test_osm.py
@@ -1,0 +1,16 @@
+import pytest
+
+from pandana.loaders import osm
+
+
+@pytest.fixture
+def bbox():
+    return 37.8659303546, -122.2588003879, 37.8661598571, -122.2585062512
+
+
+def test_make_osm_query(bbox):
+    data = osm.make_osm_query(*bbox)
+    assert isinstance(data, dict)
+    assert len(data['elements']) == 37
+    assert len([e for e in data['elements'] if e['type'] == 'node']) == 33
+    assert len([e for e in data['elements'] if e['type'] == 'way']) == 4

--- a/pandana/loaders/tests/test_pandash5.py
+++ b/pandana/loaders/tests/test_pandash5.py
@@ -1,0 +1,137 @@
+import os
+import tempfile
+
+import pandas as pd
+import pytest
+
+import pandas.util.testing as pdt
+from pandana import Network
+from pandana.testing import skipiftravis
+
+from pandana.loaders import pandash5 as ph5
+
+
+@pytest.fixture(scope='module')
+def nodes():
+    return pd.DataFrame(
+        {'x': [1, 2, 3, 4] * 3,
+         'y': [1] * 4 + [2] * 4 + [3] * 4})
+
+
+@pytest.fixture(scope='module')
+def edges():
+    return pd.DataFrame(
+        {'from': [0, 4, 5, 6, 2, 2, 6, 10, 9, 7],
+         'to': [4, 5, 6, 2, 1, 3, 10, 9, 8, 11]})
+
+
+@pytest.fixture(scope='module')
+def impedance_names():
+    return ['distance', 'time']
+
+
+@pytest.fixture(scope='module')
+def edge_weights(edges, impedance_names):
+    return pd.DataFrame(
+        {impedance_names[0]: [1] * len(edges),
+         impedance_names[1]: range(1, len(edges) + 1)})
+
+
+@pytest.fixture(scope='module')
+def two_way():
+    return True
+
+
+@pytest.fixture(scope='module')
+def network(nodes, edges, edge_weights, two_way):
+    return Network(
+        nodes['x'], nodes['y'], edges['from'], edges['to'], edge_weights,
+        two_way)
+
+
+@pytest.fixture(scope='module')
+def edges_df(edges, edge_weights):
+    return edges.join(edge_weights)
+
+
+@pytest.fixture(scope='module')
+def rm_nodes():
+    return [0, 7, 6]
+
+
+@pytest.fixture
+def tmpfile(request):
+    fname = tempfile.NamedTemporaryFile().name
+
+    def cleanup():
+        if os.path.exists(fname):
+            os.remove(fname)
+    request.addfinalizer(cleanup)
+
+    return fname
+
+
+@skipiftravis
+def test_remove_nodes(network, rm_nodes):
+    # node 0 is connected to node 4, which is in turn connected to node 5
+    # node 7 is connected to node 11, which has no other connections
+    # node 6 is connected to nodes 2, 5, and 10,
+    #     which all have other connections
+    nodes, edges = ph5.remove_nodes(network, rm_nodes)
+
+    exp_nodes = pd.DataFrame(
+        {'x': [2, 3, 4, 1, 2, 1, 2, 3, 4],
+         'y': [1, 1, 1, 2, 2, 3, 3, 3, 3]},
+        index=[1, 2, 3, 4, 5, 8, 9, 10, 11])
+
+    exp_edges = pd.DataFrame(
+        {'from': [4, 2, 2, 10, 9],
+         'to': [5, 1, 3, 9, 8],
+         'distance': [1, 1, 1, 1, 1],
+         'time': [2, 5, 6, 8, 9]},
+        index=[1, 4, 5, 7, 8])
+    exp_edges = exp_edges[['from', 'to', 'distance', 'time']]  # order columns
+
+    pdt.assert_frame_equal(nodes, exp_nodes)
+    pdt.assert_frame_equal(edges, exp_edges)
+
+
+@skipiftravis
+def test_network_to_pandas_hdf5(
+        tmpfile, network, nodes, edges_df, impedance_names, two_way):
+    ph5.network_to_pandas_hdf5(network, tmpfile)
+
+    store = pd.HDFStore(tmpfile)
+
+    pdt.assert_frame_equal(store['nodes'], nodes)
+    pdt.assert_frame_equal(store['edges'], edges_df)
+    pdt.assert_series_equal(store['two_way'], pd.Series([two_way]))
+    pdt.assert_series_equal(
+        store['impedance_names'], pd.Series(impedance_names))
+
+
+@skipiftravis
+def test_network_to_pandas_hdf5_removal(
+        tmpfile, network, impedance_names, two_way, rm_nodes):
+    nodes, edges = ph5.remove_nodes(network, rm_nodes)
+    ph5.network_to_pandas_hdf5(network, tmpfile, rm_nodes)
+
+    store = pd.HDFStore(tmpfile)
+
+    pdt.assert_frame_equal(store['nodes'], nodes)
+    pdt.assert_frame_equal(store['edges'], edges)
+    pdt.assert_series_equal(store['two_way'], pd.Series([two_way]))
+    pdt.assert_series_equal(
+        store['impedance_names'], pd.Series(impedance_names))
+
+
+@skipiftravis
+def test_network_from_pandas_hdf5(
+        tmpfile, network, nodes, edges_df, impedance_names, two_way):
+    ph5.network_to_pandas_hdf5(network, tmpfile)
+    new_net = ph5.network_from_pandas_hdf5(tmpfile)
+
+    pdt.assert_frame_equal(new_net.nodes_df, nodes)
+    pdt.assert_frame_equal(new_net.edges_df, edges_df)
+    assert new_net._twoway == two_way
+    assert new_net.impedance_names == impedance_names

--- a/pandana/loaders/tests/test_pandash5.py
+++ b/pandana/loaders/tests/test_pandash5.py
@@ -129,9 +129,23 @@ def test_network_to_pandas_hdf5_removal(
 def test_network_from_pandas_hdf5(
         tmpfile, network, nodes, edges_df, impedance_names, two_way):
     ph5.network_to_pandas_hdf5(network, tmpfile)
-    new_net = ph5.network_from_pandas_hdf5(tmpfile)
+    new_net = ph5.network_from_pandas_hdf5(Network, tmpfile)
 
     pdt.assert_frame_equal(new_net.nodes_df, nodes)
     pdt.assert_frame_equal(new_net.edges_df, edges_df)
+    assert new_net._twoway == two_way
+    assert new_net.impedance_names == impedance_names
+
+
+@skipiftravis
+def test_network_save_load_hdf5(
+        tmpfile, network, impedance_names, two_way, rm_nodes):
+    network.save_hdf5(tmpfile, rm_nodes)
+    new_net = Network.from_hdf5(tmpfile)
+
+    nodes, edges = ph5.remove_nodes(network, rm_nodes)
+
+    pdt.assert_frame_equal(new_net.nodes_df, nodes)
+    pdt.assert_frame_equal(new_net.edges_df, edges)
     assert new_net._twoway == two_way
     assert new_net.impedance_names == impedance_names

--- a/pandana/loaders/tests/test_pandash5.py
+++ b/pandana/loaders/tests/test_pandash5.py
@@ -149,3 +149,11 @@ def test_network_save_load_hdf5(
     pdt.assert_frame_equal(new_net.edges_df, edges)
     assert new_net._twoway == two_way
     assert new_net.impedance_names == impedance_names
+
+
+# this is an odd place for this test because it's not related to HDF5,
+# but my test Network is perfect.
+@skipiftravis
+def test_network_low_connectivity_nodes(network, impedance_names):
+    nodes = network.low_connectivity_nodes(10, 3, imp_name=impedance_names[0])
+    assert list(nodes) == [7, 11]

--- a/pandana/network.py
+++ b/pandana/network.py
@@ -123,6 +123,8 @@ class Network:
                                    .as_matrix().astype('float32'),
                                twoway)
 
+        self._twoway = twoway
+
     def _node_indexes(self, node_ids):
         # for some reason, merge is must faster than .loc
         df = pd.merge(pd.DataFrame({"node_ids": node_ids}),

--- a/pandana/network.py
+++ b/pandana/network.py
@@ -522,3 +522,37 @@ class Network:
         df = pd.DataFrame(a, index=self.node_ids)
         df.columns = range(1, num_pois+1)
         return df
+
+    def low_connectivity_nodes(self, impedance, count, imp_name=None):
+        """
+        Identify nodes that are connected to fewer than some threshold
+        of other nodes within a given distance.
+
+        Parameters
+        ----------
+        impedance : float
+            Distance within which to search for other connected nodes.
+        count : int
+            Threshold for connectivity. If a node is connected to fewer
+            than this many nodes within `impedance` it will be identified
+            as "low connectivity".
+        imp_name : string, optional
+            The impedance name to use for the aggregation on this network.
+            Must be one of the impedance names passed in the constructor of
+            this object.  If not specified, there must be only one impedance
+            passed in the constructor, which will be used.
+
+        Returns
+        -------
+        node_ids : array
+            List of "low connectivity" node IDs.
+
+        """
+        # set a counter variable on all nodes
+        self.set(self.node_ids.to_series(), name='counter')
+
+        # count nodes within impedance range
+        agg = self.aggregate(
+            impedance, type='count', imp_name=imp_name, name='counter')
+
+        return np.array(agg[agg < count].index)

--- a/pandana/network.py
+++ b/pandana/network.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 
 from . import _pyaccess
+from .loaders import pandash5 as ph5
 
 MAX_NUM_NETWORKS = 0
 NUM_NETWORKS = 0
@@ -124,6 +125,36 @@ class Network:
                                twoway)
 
         self._twoway = twoway
+
+    @classmethod
+    def from_hdf5(cls, filename):
+        """
+        Load a previously saved Network from a Pandas HDF5 file.
+
+        Parameters
+        ----------
+        filename : str
+
+        Returns
+        -------
+        network : pandana.Network
+
+        """
+        return ph5.network_from_pandas_hdf5(cls, filename)
+
+    def save_hdf5(self, filename, rm_nodes=None):
+        """
+        Save network data to a Pandas HDF5 file.
+
+        Parameters
+        ----------
+        filename : str
+        rm_nodes : array_like
+            A list, array, Index, or Series of node IDs that should *not*
+            be saved as part of the Network.
+
+        """
+        ph5.network_to_pandas_hdf5(self, filename, rm_nodes)
 
     def _node_indexes(self, node_ids):
         # for some reason, merge is must faster than .loc

--- a/pandana/network.py
+++ b/pandana/network.py
@@ -146,6 +146,9 @@ class Network:
         """
         Save network data to a Pandas HDF5 file.
 
+        Only the nodes and edges of the actual network are saved,
+        points-of-interest and data attached to nodes are not saved.
+
         Parameters
         ----------
         filename : str

--- a/pandana/testing.py
+++ b/pandana/testing.py
@@ -1,0 +1,6 @@
+import os
+
+import pytest
+
+skipiftravis = pytest.mark.skipif(
+    os.environ.get('TRAVIS') == 'true', reason='skip on Travis-CI')

--- a/pandana/tests/test_great_circle_dist.py
+++ b/pandana/tests/test_great_circle_dist.py
@@ -1,0 +1,16 @@
+import numpy.testing as npt
+
+from pandana.utils import great_circle_dist as gcd
+
+
+def test_gcd():
+    # tested against geopy
+    # https://geopy.readthedocs.org/en/latest/#module-geopy.distance
+    lat1 = 41.49008
+    lon1 = -71.312796
+    lat2 = 41.499498
+    lon2 = -81.695391
+
+    expected = 864456.76162966
+
+    npt.assert_allclose(gcd(lat1, lon1, lat2, lon2), expected)

--- a/pandana/utils.py
+++ b/pandana/utils.py
@@ -1,51 +1,38 @@
-from shapely.geometry import Point
-from fiona import crs
-import geopandas as gpd
-import pandas as pd
-import numpy as np
+from __future__ import division
+
+import math
 
 
-def bbox_convert(bbox, from_epsg, to_epsg):
-    bbox = gpd.GeoSeries([Point(bbox[0], bbox[1]),
-                          Point(bbox[2], bbox[3])],
-                         crs=crs.from_epsg(from_epsg))
-    bbox = bbox.to_crs(epsg=to_epsg)
-    bbox = [bbox[0].x, bbox[0].y, bbox[1].x, bbox[1].y]
-    return bbox
+def great_circle_dist(lat1, lon1, lat2, lon2):
+    """
+    Get the distance (in meters) between two lat/lon points
+    via the Haversine formula.
 
+    Parameters
+    ----------
+    lat1, lon1, lat2, lon2 : float
+        Latitude and longitude in degrees.
 
-def get_nodes_from_osm(bbox, query, to_epsg=3740):
-    gdf = gpd.io.osm.query_osm('node',
-                               bbox=bbox,
-                               tags=query)
-    gdf = gdf[gdf.type == 'Point'].to_crs(epsg=to_epsg)
-    print "Found %d nodes" % len(gdf)
-    x, y = zip(*[(p.x, p.y) for (i, p)
-               in gdf.geometry.iteritems()])
-    x = pd.Series(x)
-    y = pd.Series(y)
-    return x, y
+    Returns
+    -------
+    dist : float
+        Distance in meters.
 
+    """
+    radius = 6372795  # meters
 
-def anything_score(net, config, max_distance, decay, bbox):
-    score = pd.Series(np.zeros(len(net.node_ids)), index=net.node_ids)
-    for query, weights in config.iteritems():
-        print "Computing for query: %s" % query
-        print "Fetching nodes from OSM"
-        x, y = get_nodes_from_osm(bbox, query)
-        print "Done"
-        net.set_pois(query, x, y)
-        print "Computing nearest"
-        df = net.nearest_pois(max_distance, query, num_pois=len(weights))
-        print "Done"
+    lat1 = math.radians(lat1)
+    lon1 = math.radians(lon1)
+    lat2 = math.radians(lat2)
+    lon2 = math.radians(lon2)
 
-        for idx, weight in enumerate(weights):
-            # want the 1st not the 0th
-            idx += 1
-            print "Adding contribution %f for number %d nearest" % \
-                  (weight, idx)
-            score += decay(df[idx])*weight
-            # print score.describe()
+    dlat = lat2 - lat1
+    dlon = lon2 - lon1
 
-    assert score.min() > 0
-    return score/score.max()*100
+    # formula from:
+    # http://en.wikipedia.org/wiki/Haversine_formula#The_haversine_formula
+    a = math.pow(math.sin(dlat / 2), 2)
+    b = math.cos(lat1) * math.cos(lat2) * math.pow(math.sin(dlon / 2), 2)
+    d = 2 * radius * math.asin(math.sqrt(a + b))
+
+    return d

--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,7 @@ setup(
         'matplotlib>=1.3.1',
         'numpy>=1.8.0',
         'pandas>=0.13.1',
+        'requests>=2.0',
         'tables>=3.1.0'
     ],
     tests_require=['pytest'],


### PR DESCRIPTION
This is work in progress, but I wanted to post it for discussion.

The goal here is to be able to load road data from OSM such that it can be used to create a Pandana network.
Here's an example of the type of query I have coded in: http://overpass-turbo.eu/s/6AK. It's a "way" query for a bounding box with "recursion" so that it goes and finds all the nodes that are attached to the found ways. The actual query looks like:

```
[out:json];
(
  way(37.8659303546,-122.2588003879,37.8661598571,-122.2585062512);
  >;
);
out;
```

The JSON result of that query can be turned into three DataFrames: nodes, ways, and waynodes.

The nodes table has a schema like:

```
id    lat    lon    tag1    tag2 ...
```

The ways table has a schema like:

```
id tag1 tag2 ...
```

And the waynodes table has a schema like:

```
way_id    node_id
```

In each of those the first column is really the index.

@fscottfoti, is that the kind of information we need, or is there more? We could also filter this to certain tags, like `["highway"="*"]` so we only get road ways (I think, my understanding of OSM data is still developing).