### PR TITLE
Basemap plot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ install:
   python=$TRAVIS_PYTHON_VERSION
   matplotlib numpy pandas pip pytables requests
 - source activate test-environment
-- pip install brewer2mpl
 - pip install pytest-cov coveralls pep8
 - python setup.py install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 - >
   conda create -q -c synthicity -n test-environment
   python=$TRAVIS_PYTHON_VERSION
-  matplotlib numpy pandas pip pytables requests
+  basemap matplotlib numpy pandas pip pytables requests
 - source activate test-environment
 - pip install pytest-cov coveralls pep8
 - python setup.py install

--- a/pandana/tests/test_pandana.py
+++ b/pandana/tests/test_pandana.py
@@ -23,11 +23,6 @@ def sample_osm(request):
     net = pdna.Network(nodes.x, nodes.y, edges["from"], edges.to,
                        edges[["weight"]])
 
-    # try again to test for crash
-    with pytest.raises(AssertionError):
-        net = pdna.Network(nodes.x, nodes.y, edges["from"], edges.to,
-                           edges[["weight"]])
-
     net.precompute(2000)
 
     def fin():
@@ -116,7 +111,7 @@ def test_named_variable(sample_osm):
     net.set(random_node_ids(sample_osm, ssize),
             variable=random_data(ssize), name="foo")
 
-    s = net.aggregate(500, type="sum", decay="linear", name="foo")
+    net.aggregate(500, type="sum", decay="linear", name="foo")
 
 
 def test_plot(sample_osm):
@@ -128,7 +123,7 @@ def test_plot(sample_osm):
 
     s = net.aggregate(500, type="sum", decay="linear")
 
-    sample_osm.plot(s, bbox=net.bbox)
+    sample_osm.plot(s)
 
 
 def test_pois(sample_osm):
@@ -142,19 +137,19 @@ def test_pois(sample_osm):
         net.set_pois("restaurants", x, y)
 
     with pytest.raises(AssertionError):
-        _ = net.nearest_pois(2000, "restaurants", num_pois=10)
+        net.nearest_pois(2000, "restaurants", num_pois=10)
 
     net.init_pois(num_categories=1, max_dist=2000, max_pois=10)
 
     with pytest.raises(AssertionError):
-        _ = net.nearest_pois(2000, "restaurants", num_pois=10)
+        net.nearest_pois(2000, "restaurants", num_pois=10)
 
     # boundary condition
     net.init_pois(num_categories=1, max_dist=2000, max_pois=10)
 
     net.set_pois("restaurants", x, y)
 
-    _ = net.nearest_pois(2000, "restaurants", num_pois=10)
+    net.nearest_pois(2000, "restaurants", num_pois=10)
 
     with pytest.raises(AssertionError):
-        _ = net.nearest_pois(2000, "restaurants", num_pois=11)
+        net.nearest_pois(2000, "restaurants", num_pois=11)

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,6 @@ setup(
         )
     ],
     install_requires=[
-        'brewer2mpl>=1.4',
         'matplotlib>=1.3.1',
         'numpy>=1.8.0',
         'pandas>=0.13.1',


### PR DESCRIPTION
Works with a Series that has the same index as nodes and some data value. Requires a data point for every node. Plot types are limited to scatter or hexbin. Sample:

```python
bmap, fig, ax = net.plot(
    nearest, plot_type='hexbin',
    fig_kwargs={'figsize': (8, 8), 'facecolor': 'white'},
    bmap_kwargs={'resolution': 'h'},
    plot_kwargs={'cmap': plt.cm.YlGnBu, 'reduce_C_function': np.min},
    cbar_kwargs={'location': 'bottom', 'label': 'Distance (meters)'})
```

![east_bay_min_dist_to_cafe](https://cloud.githubusercontent.com/assets/920492/5964928/efead182-a7ac-11e4-9d9e-035c72cc9d92.png)
